### PR TITLE
Correction chargement du module CRUD

### DIFF
--- a/livre/part00-je-suis-nul/ch03-Premiere-application-CRUD.md
+++ b/livre/part00-je-suis-nul/ch03-Premiere-application-CRUD.md
@@ -34,25 +34,28 @@ Et tout ceci facilement et rapidement
 
 Donc pour activer le module CRUD :
 
-* aller dans `/azerguespeche/conf/application.conf`
-* ajouter ceci :
+* aller dans `/azerguespeche/conf/dependencies.conf`
+* ajouter ceci sur une nouvelle ligne à la suite de `- play` :
 
-        # Import CRUD module
-        module.crud=${play.path}/modules/crud
+        - play -> crud
 
 * aller dans le fichier routes `/azerguespeche/conf/routes`
-* ajouter ceci :
+        
+* Ajouter ceci : juste après `GET /   Application.index`
 
         # Import CRUD routes
         * /admin module:crud
 
-* Et ceci : juste après `GET /   Application.index`
-
-        GET /admin  module:crud`
-
 *Note : on vient d'expliquer à Play! que l'on utilise le module CRUD lorsque l'on utilise l'url [http://localhost:9000/admin/](http://localhost:9000/admin/)*
 
-**Avant de continuer, arrêtez puis relancez votre application :**
+**Avant de continuer, arrêtez votre application :**
+
+En ligne de commande, taper : play dependencies
+
+Cette commande permet d'installer les modules et/ou bibliothèques externes déclarés dans le fichier dependencies.yml.
+Donc si tout se passe bien vous devriez voir un message indiquant que le module CRUD a été installé.
+
+**A présent, vous pouvez relancer votre application :**
 
 donc avec la commande : `play run azerguespeche` en mode console.
 

--- a/livre/part00-je-suis-nul/ch03-Premiere-application-CRUD.md
+++ b/livre/part00-je-suis-nul/ch03-Premiere-application-CRUD.md
@@ -50,7 +50,7 @@ Donc pour activer le module CRUD :
 
 **Avant de continuer, arrêtez votre application :**
 
-En ligne de commande, taper : play dependencies
+En ligne de commande, taper : `play dependencies`
 
 Cette commande permet d'installer les modules et/ou bibliothèques externes déclarés dans le fichier dependencies.yml.
 Donc si tout se passe bien vous devriez voir un message indiquant que le module CRUD a été installé.


### PR DESCRIPTION
une petite correction sur la façon dont est chargé le module CRUD dans le chapitre 3. Chargement des modules à partir du fichier dependencies.yml et de la commande play depencies (depuis la vers 1.2.1 il me semble).
